### PR TITLE
build(docker-compose): add docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ethgasstation-api Dockerfile
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 ENV NODE_ENV production
 ENV PORT 8080
@@ -8,7 +8,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 
 RUN mkdir -p /opt/ethgasstation/api

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ docker build -t ethgasstation-api .
 docker run -p 8080:8080 ethgasstation-api
 ```
 
+A compose.yml is included for deployment as well. To run the Docker compose 
+with MariaDB, redis and ethgas station API. **(you need to have ethgasstation_backend running and eth-node)**:
+
+```
+docker-compose -f compose.yml build
+docker-compose -f compose.yml up
+```
+
 This will expose and forward port 8080 from the image. Note that the docker
 image runs in production mode by default.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,27 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+    mariadb:
+        image: mariadb
+        restart: always
+        environment:
+            MYSQL_USER: ethgas
+            MYSQL_PASSWORD: station
+            MYSQL_DATABASE: tx
+            MYSQL_ROOT_PASSWORD: nopasanada
+
+    redis:
+        image: redis:3.2
+        container_name: redis
+
+    ethgasstation_api:
+        build:
+            context: ./
+            dockerfile: ./Dockerfile
+        image: ethgasstation-api
+        ports:
+            - "8080:8080"
+        depends_on: 
+            - mariadb
+            - redis


### PR DESCRIPTION
Add docker-compose with MariaDB, Redis and the Ethgas Station API.

This take easy to mount all the infrastructure